### PR TITLE
Modification for python 3, updated to asciidoctor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A [Lektor](https://www.getlektor.com/) plugin to add an AsciiDoc field type.
 
+## Requirements
+
+This version of lektor asciidoc requires ruby and asciidoctor. See go to [asciidoctor.org](https://asciidoctor.org/docs/install-toolchain/) and [ruby-lang.org](https://asciidoctor.org/docs/install-toolchain/) for installation instructions.
+
 ## Installation
 
 Add lektor-asciidoc to your project from command line:
@@ -9,3 +13,4 @@ Add lektor-asciidoc to your project from command line:
 ```
 lektor plugins add lektor-asciidoc
 ```
+

--- a/lektor_asciidoc.py
+++ b/lektor_asciidoc.py
@@ -6,12 +6,12 @@ from lektor.types import Type
 
 
 def asciidoc_to_html(text):
-    p = Popen(['asciidoc', '--no-header-footer', '--backend=html5', '-'],
+    p = Popen(['asciidoctor', '-s','-'],
               stdin=PIPE, stdout=PIPE, stderr=PIPE)
 
-    out, err = p.communicate(text)
-    if p.returncode != 0:
-        raise RuntimeError('asciidoc: "%s"' % err)
+    out, err = p.communicate(text.encode('utf-8'))
+    if p.returncode !=  0:
+        raise RuntimeError('asciidoctor: "%s"' % err)
 
     return out
 
@@ -29,7 +29,7 @@ class AsciiDocType(Type):
     widget = 'multiline-text'
 
     def value_from_raw(self, raw):
-        return HTML(asciidoc_to_html(raw.value or u''))
+        return HTML(asciidoc_to_html(raw.value or u'').decode('utf-8'))
 
 
 class AsciiDocPlugin(Plugin):

--- a/lektor_asciidoc.py
+++ b/lektor_asciidoc.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import sys
 from subprocess import PIPE, Popen
 
 from lektor.pluginsystem import Plugin
@@ -8,8 +9,11 @@ from lektor.types import Type
 def asciidoc_to_html(text):
     p = Popen(['asciidoctor', '-s','-'],
               stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    if sys.version_info[0] < 3:
+        out, err = p.communicate(text)
+    else:
+        out, err = p.communicate(text.encode('utf-8'))
 
-    out, err = p.communicate(text.encode('utf-8'))
     if p.returncode !=  0:
         raise RuntimeError('asciidoctor: "%s"' % err)
 
@@ -29,7 +33,10 @@ class AsciiDocType(Type):
     widget = 'multiline-text'
 
     def value_from_raw(self, raw):
-        return HTML(asciidoc_to_html(raw.value or u'').decode('utf-8'))
+        if sys.version_info[0] < 3:
+            return HTML(asciidoc_to_html(raw.value or u''))
+        else:
+            return HTML(asciidoc_to_html(raw.value or u'').decode('utf-8'))
 
 
 class AsciiDocPlugin(Plugin):

--- a/tests/demo-project/demo.lektorproject
+++ b/tests/demo-project/demo.lektorproject
@@ -1,2 +1,5 @@
 [project]
 name = demo
+
+[packages]
+lektor-asciidoc = 0.3


### PR DESCRIPTION
#2 conditional could be added to check if asciidoc (python 2 exclusively) or asciidoctor (ruby/python version agnostic) is installed; however asciidoctor is the current asciidoc implementation as stated in [here](https://github.com/asciidoc/asciidoc). Please let me know if anything additional can be done.

I'd call this a new version. What do you think?